### PR TITLE
Rework exception handling from TerminalStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+docs/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/IPScan/IPScan.cs
+++ b/IPScan/IPScan.cs
@@ -32,7 +32,6 @@ namespace IPScan
             IPInfo result = new IPInfo();
             foreach (IScanner scanner in ScannerCollection)
             {
-                scanner.Init(ScanParameters);
                 var scanResult = await scanner.Run();
                 result.Merge(scanResult);               
             }

--- a/IPScan/IPScan.csproj
+++ b/IPScan/IPScan.csproj
@@ -59,8 +59,6 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="docs\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/IPScan/Supports/IPAddressExtension.cs
+++ b/IPScan/Supports/IPAddressExtension.cs
@@ -9,7 +9,7 @@ namespace IPScan.Supports
 {
     public static class IPAddressExtension
     {
-        public static List<IPAddress> Range(this IPAddress startRange, IPAddress endRange)
+        public static IEnumerable<IPAddress> Range(this IPAddress startRange, IPAddress endRange)
         {
             var result = new List<IPAddress>();
 

--- a/IPScan/TerminalStream.cs
+++ b/IPScan/TerminalStream.cs
@@ -71,7 +71,11 @@ namespace IPScan
             }
             catch (AggregateException exc)
             {
-                ErrorViewer(exc.InnerExceptions);
+                ErrorViewer(exc.InnerExceptions.ToArray());
+            }
+            catch (Exception exc)
+            {
+                ErrorViewer(exc);
             }
         }
 
@@ -81,7 +85,7 @@ namespace IPScan
             RenderResponse(ipInfo);
         }
 
-        private static void ErrorViewer(ICollection<Exception> exceptions)
+        private static void ErrorViewer(params Exception[] exceptions)
         {
             foreach (var exception in exceptions)
             {
@@ -91,12 +95,12 @@ namespace IPScan
                 }
                 catch (ScannerException exc)
                 {
-                    RenderError("Scanner error", exc.Message);
+                    RenderError("Scanner error", exc);
                     RenderHelp();
                 }
                 catch (Exception exc)
                 {
-                    RenderError("System error", exc.Message);
+                    RenderError("System error", exc);
                 }
             }
         }
@@ -154,13 +158,13 @@ namespace IPScan
             Console.WriteLine();
         }
 
-        private static void RenderError(string title, string message)
+        private static void RenderError(string title, Exception exc)
         {
             Console.BackgroundColor = ConsoleColor.DarkRed;
             Console.ForegroundColor = ConsoleColor.White;
             Console.Write(title);
             Console.ResetColor();
-            Console.WriteLine($" {message} ");
+            Console.WriteLine($" {exc.Message} ");
         }
 
         private static void RenderLoading(string title, Func<bool> predicate, int pause = 100, int dotCount = 3)


### PR DESCRIPTION
Reforged the second argument from RenderError to Exception. Reforged the argument from ErrorViewer to params*, in order to accept any number of errors. And also fixed RenderScan in relation to the upgrade