### PR TITLE
Add correct parsing of scan parameters

### DIFF
--- a/IPScan/IPScan.cs
+++ b/IPScan/IPScan.cs
@@ -32,4 +32,9 @@ namespace IPScan
 
         private IPScanParameters _scanParameters;
     }
+
+    public class IPScanException : Exception
+    {
+        // your advertisement could be here...
+    }
 }

--- a/IPScan/IPScan.csproj
+++ b/IPScan/IPScan.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IPScanParameters.cs" />
-    <Compile Include="Supports\KeyAttribute.cs" />
+    <Compile Include="Supports\KeySetterAttribute.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IPScan.cs" />

--- a/IPScan/IPScanParameters.cs
+++ b/IPScan/IPScanParameters.cs
@@ -6,36 +6,105 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Reflection;
 using IPScan.Supports;
+using System.Collections.ObjectModel;
 
 namespace IPScan
 {
     public class IPScanParameters
     {
-        [Key("-ip", "Address or range", true)]
+        // required
         public IPAddress Address { get; set; }
 
-        [Key("-t", "Timeout")]
-        public int Timeout { get; set; }
+        // default
+        public int Timeout { get; set; } = 1000;
+        public int Port { get; set; } = 0;
 
-        [Key("-p", "Port")]
-        public int Port { get; set; }
 
+        /// <summary>
+        /// Parsing a string dictionary to IPScanParameters with instance properties
+        /// </summary>
+        /// <param name="collection">Key collection</param>
+        /// <returns>IPScan parameters</returns>
         public static IPScanParameters Parse(Dictionary<string, string> collection)
         {
             var parameters = new IPScanParameters();
 
-            parameters.Address = IPAddress.Parse(collection["-ip"]);
-            parameters.Timeout = Int32.Parse(collection["-t"]);
+            foreach(var field in collection)
+            {
+                var setter = parameters.GetSetter(field.Key);
+                setter?.Invoke(parameters, new[] { field.Value });
+            }
 
             return parameters;
         }
 
-        private KeyAttribute GetKeyAttribute(string key)
+        /// <summary>
+        /// Checking required keys
+        /// </summary>
+        /// <param name="collection">Key collection</param>
+        /// <returns>Returns true if the required keys exists in the collection</returns>
+        public static bool CheckingRequiredKeys(Dictionary<string, string> collection)
         {
-            var attributes = GetType().GetCustomAttributes<KeyAttribute>();
-            return attributes.FirstOrDefault(a => a.Key == key);
+            var isCheck = true;
+
+            foreach(var keySetter in GetKeySetters())
+            {
+                var field = collection.FirstOrDefault(f => f.Key == keySetter.Key);
+
+                if(keySetter.IsRequired == true && field.Value == null)
+                {
+                    isCheck = false;
+                }
+            }
+
+            return isCheck;
         }
 
-        private IEnumerable<KeyAttribute> GetKeyAttributes() => GetType().GetCustomAttributes<KeyAttribute>();
+
+        /// <summary>
+        /// Return key setters collection(*for help)
+        /// </summary>
+        /// <returns>KeySetter collection</returns>
+        public static IEnumerable<KeySetterAttribute> GetKeySetters()
+        {
+            var keySetters = new Collection<KeySetterAttribute>();
+            var setters = new IPScanParameters().GetSetters();
+
+            foreach(var setter in setters)
+            {
+                keySetters.Add(setter.GetCustomAttribute<KeySetterAttribute>());
+            }
+
+            return keySetters;
+        }
+
+        #region Setters
+        [KeySetter("-ip", "Address or range", true)]
+        public void AddressSetter(string value)
+        {
+            Address = IPAddress.Parse(value);
+        }
+
+        [KeySetter("-t", "Timeout")]
+        public void TimeoutSetter(string value)
+        {
+            Timeout = Int32.Parse(value);
+        }
+
+        [KeySetter("-p", "Port")]
+        public void PortSetter(string value)
+        {
+            Port = Int32.Parse(value);
+        }
+        #endregion
+
+
+        #region Tools
+        private MethodInfo GetSetter(string key) => 
+            GetSetters().FirstOrDefault(s => s.GetCustomAttribute<KeySetterAttribute>().Key == key);
+
+        private IEnumerable<MethodInfo> GetSetters() => 
+            GetType().GetMethods().Where(m => m.GetCustomAttribute<KeySetterAttribute>() != null);
+        #endregion
     }
 }

--- a/IPScan/Supports/KeySetterAttribute.cs
+++ b/IPScan/Supports/KeySetterAttribute.cs
@@ -10,15 +10,15 @@ namespace IPScan.Supports
     /// Declaration an option key with an description
     /// and the default value
     /// </summary>
-    [AttributeUsage(AttributeTargets.Property)]
-    public class KeyAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Method)]
+    public class KeySetterAttribute : Attribute
     {
         /// <summary>
         /// Declarate an option key
         /// </summary>
         /// <param name="key">For example '-k'</param>
         /// <param name="description">Key description</param>
-        public KeyAttribute(string key, string description, bool isRequired = false)
+        public KeySetterAttribute(string key, string description, bool isRequired = false)
         {
             Key = key;
             Description = description;


### PR DESCRIPTION
Reworked attributes to KeySetterAttribute, now they for a method. IPScanParameters can now correctly parsing the properties of the instance through special property setters. Added CheckingRequiredKeys() for a checking exists required keys in collection.